### PR TITLE
Use rl_clear_history only if available, fallback to clear_history if not

### DIFF
--- a/client/readline.c
+++ b/client/readline.c
@@ -917,6 +917,10 @@ void readline_exit(void)
 {
 	if (!quit)
 		rl_callback_handler_remove();
+#if (RL_VERSION_MAJOR<=5 || (RL_VERSION_MAJOR==6 && RL_VERSION_MINOR<=3))
+	clear_history();
+#else
 	rl_clear_history();
+#endif
 }
 


### PR DESCRIPTION
For ancient readline (I'm stuck to it on a embedded target...),
rl_clear_history is not available, so using clear_history instead.