### PR TITLE
Wimplicit_fallthrough requires gcc7 or newer, so only enable it there.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,11 @@ set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointe
 set(CMAKE_C_FLAGS_LTO "${CMAKE_C_FLAGS_RELEASE} -flto")
 set(CMAKE_EXE_LINKER_FLAGS_LTO "${CMAKE_LINKER_FLAGS_RELEASE} -flto")
 
-add_compile_options(-Wall -Wextra -Werror -Werror -Wno-implicit-fallthrough)
+add_compile_options(-Wall -Wextra)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 7)
+		add_compile_option(-Wno-implicit-fallthrough)
+endif()
 
 if (NOT DISABLE_CLIENT)
 	SET(C_SRCS


### PR DESCRIPTION
Also disable -Werror, as this is a great annoyance and breaks the build
with (newer|older) gccs or when some hardening options are enabled.