### PR TITLE
Fix arm compile issues

### DIFF
--- a/dwarf.h
+++ b/dwarf.h
@@ -58,6 +58,7 @@
 #define DWARF_EINVAL		4	/* unsupported operation or bad value */
 #define DWARF_EBADVERSION	5	/* unwind info has unsupported version */
 #define DWARF_ENOINFO		6	/* no unwind info found */
+#define DWARF_STOPUNWIND 	7
 
 struct dwarf_cie_info {
 	arch_addr_t start_ip;		/* first IP covered by this procedure */

--- a/sysdeps/linux-gnu/arm/arch.c
+++ b/sysdeps/linux-gnu/arm/arch.c
@@ -47,6 +47,7 @@
 
 int is_64bit(struct mt_elf *mte)
 {
+	(void)(mte);
 	return 0;
 }
 

--- a/sysdeps/linux-gnu/arm/arch.c
+++ b/sysdeps/linux-gnu/arm/arch.c
@@ -691,7 +691,7 @@ int do_singlestep(struct task *task, struct breakpoint *bp)
 
 	bp1 = breakpoint_find(task, next_pcs[0]);
 	if (!bp1) {
-		bp1 = breakpoint_new(task, next_pcs[0], NULL, SW_BP);
+		bp1 = breakpoint_new(task, next_pcs[0], NULL, BP_SW);
 		if (!bp1)
 			return -1;
 	}
@@ -703,7 +703,7 @@ int do_singlestep(struct task *task, struct breakpoint *bp)
 	if (next_pcs[1]) {
 		bp2 = breakpoint_find(task, next_pcs[1]);
 		if (!bp2) {
-			bp2 = breakpoint_new(task, next_pcs[1], NULL, SW_BP);
+			bp2 = breakpoint_new(task, next_pcs[1], NULL, BP_SW);
 			if (!bp2)
 				return -1;
 		}

--- a/sysdeps/linux-gnu/arm/dwarf-arm.c
+++ b/sysdeps/linux-gnu/arm/dwarf-arm.c
@@ -177,10 +177,10 @@ static inline int access_mem(struct dwarf_addr_space *as, arch_addr_t addr, void
 		struct dwarf_cursor *c = &as->cursor;
 		struct libref *libref = c->libref;
 
-		if (addr < ARCH_ADDR_T(libref->image_addr))
-			fatal("invalid access mem: addr %#lx < %p", addr, libref->image_addr);
-		if (addr >= ARCH_ADDR_T(libref->image_addr + libref->load_size))
-			fatal("invalid access mem: addr %#lx >= %p", addr, libref->image_addr + libref->load_size);
+		if (addr < ARCH_ADDR_T(libref->mmap_addr))
+			fatal("invalid access mem: addr %#lx < %p", addr, libref->mmap_addr);
+		if (addr >= ARCH_ADDR_T(libref->mmap_addr + libref->mmap_size))
+			fatal("invalid access mem: addr %#lx >= %p", addr, libref->mmap_addr + libref->mmap_size);
 	}
 #endif
 
@@ -506,7 +506,7 @@ static unsigned long arm_search_unwind_table(struct dwarf_addr_space *as, arch_a
 {
 	struct dwarf_cursor *c = &as->cursor;
 	struct libref *libref = c->libref;
-	unsigned long map_offset = (unsigned long)libref->image_addr + libref->load_offset - libref->load_addr;
+	unsigned long map_offset = (unsigned long)libref->mmap_addr + libref->mmap_offset - libref->txt_vaddr;
 	unsigned long lo, hi, e, f;
 	arch_addr_t val;
 

--- a/sysdeps/linux-gnu/arm/dwarf-arm.c
+++ b/sysdeps/linux-gnu/arm/dwarf-arm.c
@@ -32,7 +32,7 @@
 #include "common.h"
 #include "backend.h"
 #include "debug.h"
-#include "dwarf.h"
+#include "../../../dwarf.h"
 #include "library.h"
 #include "task.h"
 

--- a/sysdeps/linux-gnu/arm/dwarf-arm.c
+++ b/sysdeps/linux-gnu/arm/dwarf-arm.c
@@ -153,6 +153,7 @@ static int is_signal_frame(struct dwarf_cursor *c)
 
 int dwarf_arch_map_reg(struct dwarf_addr_space *as, unsigned int reg)
 {
+	(void)(as);
 	if (reg >= ARRAY_SIZE(dwarf_to_regnum_map))
 		return -DWARF_EBADREG;
 
@@ -182,6 +183,8 @@ static inline int access_mem(struct dwarf_addr_space *as, arch_addr_t addr, void
 		if (addr >= ARCH_ADDR_T(libref->mmap_addr + libref->mmap_size))
 			fatal("invalid access mem: addr %#lx >= %p", addr, libref->mmap_addr + libref->mmap_size);
 	}
+#else
+	(void)(as);
 #endif
 
 	memcpy(valp, (void *)addr, size);
@@ -647,6 +650,8 @@ int dwarf_arch_step(struct dwarf_addr_space *as)
 
 int dwarf_arch_check_call(struct dwarf_addr_space *as, arch_addr_t ip)
 {
+	(void)(as);
+	(void)(ip);
 	return 1;
 }
 


### PR DESCRIPTION
- fix "unused parameter" warning
- s/SW_BP/BP_SW/
- specify relative path to project's dwarf.h to avoid that system one is picked up instead
- struct libref members have been renamed previously, adapt this changes.
