### PR TITLE
Bugfixes mmap

### DIFF
--- a/client/process.c
+++ b/client/process.c
@@ -604,7 +604,7 @@ static struct rb_block *process_rb_search_range(struct rb_root *root, unsigned l
 	while (node) {
 		struct rb_block *this = container_of(node, struct rb_block, node);
 
-		if ((addr <= this->addr) && (addr + size > this->addr))
+		if ((this->addr <= addr) && (this->addr + this->size > addr))
 			return this;
 
 		if (addr < this->addr)

--- a/client/process.c
+++ b/client/process.c
@@ -1500,7 +1500,7 @@ void process_free(struct process *process, struct mt_msg *mt_msg, void *payload)
 void process_realloc_done(struct process *process, struct mt_msg *mt_msg, void *payload)
 {
 	unsigned long ptr;
-	unsigned int pid;
+	unsigned long pid;
 	struct list_head *it;
 
 	(void)mt_msg;
@@ -1536,7 +1536,7 @@ void process_realloc_done(struct process *process, struct mt_msg *mt_msg, void *
 	}
 
 	if (unlikely(options.kill)) {
-		fprintf(stderr, ">>> unexpected realloc done pid: %u ptr: %#lx\n", pid, ptr);
+		fprintf(stderr, ">>> unexpected realloc done pid: %lu ptr: %#lx\n", pid, ptr);
 		abort();
 	}
 	return;

--- a/report.c
+++ b/report.c
@@ -294,19 +294,24 @@ static void _report_mmap64(struct task *task, struct library_symbol *libsym)
 	report_alloc(task, MT_MMAP64, ret, size.l, options.bt_depth, libsym);
 }
 
-static void report_munmap(struct task *task, struct library_symbol *libsym)
+static void _report_munmap(struct task *task, struct library_symbol *libsym)
 {
 	unsigned long addr = fetch_param(task, 0);
 	unsigned long size = fetch_param(task, 1);
-	if (unlikely(arch_pagesize==-1)) arch_pagesize=getpagesize();
+	unsigned long ret = fetch_retval(task);
+
+	if(ret != 0 ) return;
+
+	if(unlikely(arch_pagesize==-1)) arch_pagesize=getpagesize();
 
 	// fixup size, if needed: all pages in [addr, addr+size] are unmapped -- see munmap(2)
-	if (size % arch_pagesize) {
+	if(size % arch_pagesize) {
 		size += arch_pagesize - size % arch_pagesize;
 	}
 
 	report_alloc(task, MT_MUNMAP, addr, size, 0, libsym);
 }
+
 
 static void _report_memalign(struct task *task, struct library_symbol *libsym)
 {
@@ -388,7 +393,7 @@ static const struct function flist[] = {
 	{ "posix_memalign",					"posix_memalign",	0,	NULL,			_report_posix_memalign },
 	{ "mmap",						"mmap",			0,	NULL,			_report_mmap },
 	{ "mmap64",						"mmap64",		1,	NULL,			_report_mmap64 },
-	{ "munmap",						"munmap",		0,	report_munmap,		NULL },
+	{ "munmap",						"munmap",		0,	NULL,			_report_munmap },
 	{ "memalign",						"memalign",		0,	NULL,			_report_memalign },
 	{ "aligned_alloc",					"aligned_alloc",	1,	NULL,			_report_aligned_alloc },
 	{ "valloc",						"valloc",		1,	NULL,			_report_valloc },


### PR DESCRIPTION
This PR fixes several issues around the handling of mmaps as well as (some of the)quirks involving mmaps...

- mmap(2) will always allocate whole memory pages, even if the
  caller only reuqests a partial page.   This is considered by calculating the "real" size of the mmap.

- munmap(2) also operates on pages, unmapping every page it "touches",   so the size parameter is adjusted if needed.

- According to munmap(2), the call can fail, e.g if the adress given is not at a page boundary.

- mremap can fail, in this case the old mapping is retained.

- mremap, when oldsize is 0, a new mapping is created without freeing
the old one.

- Fix logic error in process_rb_search_range()  The function would not properly check if addr is within the block
due to inversed logic in the comparasion.

- munmap(2) will unmap any page "it touches", the parameters
given to it do not necessarily need to match the ones given to mmap(2).
It is legit to specify pages that are not mapped at all, ranges that
span multiple mappings, with or without holes…

- A logic error in calculating the size for
process_release_mem() is fixed in the case a munmap would split
a previous allocation in two maps.

- Similar fix also for the case where the freed page is at the end
of the allocated area.
